### PR TITLE
Flasher: Add status code and corresponding message when nRF chip is locked

### DIFF
--- a/Tag_Flasher/ESP32_Flasher/include/swd.h
+++ b/Tag_Flasher/ESP32_Flasher/include/swd.h
@@ -18,7 +18,7 @@ class swd {
     bool DP_Write(unsigned addr, uint32_t data);
     bool DP_Read(unsigned addr, uint32_t &data);
 
-    uint32_t idCode;
+    uint32_t idCode = 0;
 
    protected:
     void swd_Begin();

--- a/Tag_Flasher/ESP32_Flasher/src/swd.cpp
+++ b/Tag_Flasher/ESP32_Flasher/src/swd.cpp
@@ -182,6 +182,7 @@ bool nrfswd::init() {
             isLocked = true;
         }
     } else {
+        if (showDebug) Serial0.printf("No nRF core ID found, got 0x%lx\n", temp);
         isConnected = false;
         isLocked = true;
     }

--- a/Tag_Flasher/ESP32_Flasher/src/usbflasher.cpp
+++ b/Tag_Flasher/ESP32_Flasher/src/usbflasher.cpp
@@ -513,7 +513,7 @@ void processFlasherCommand(struct flasherCommand* cmd) {
             nrfflasherp = new nrfswd(FLASHER_EXT_MISO, FLASHER_EXT_CLK);
             nrfflasherp->showDebug = false;
             nrfflasherp->init();
-            temp_buff[0] = (nrfflasherp->isConnected && !nrfflasherp->isLocked);
+            temp_buff[0] = nrfflasherp->isConnected ? (nrfflasherp->isLocked ? 2 : 1) : 0;
             sendFlasherAnswer(CMD_SELECT_NRF82511, temp_buff, 1);
             currentFlasherOffset = 0;
             selectedController = CONTROLLER_NRF82511;

--- a/Tag_Flasher/OEPL-Flasher.py
+++ b/Tag_Flasher/OEPL-Flasher.py
@@ -380,6 +380,10 @@ def main():
 
                 if (answer[0] == 1):
                     print("Connection established to microcontroller")
+                elif (answer[0] == 2):
+                    print("Established connection to the microcontroller, but it is locked. Exiting.")
+                    send_cmd(CMD_SET_POWER, bytearray([0]))
+                    exit(0)
                 else:
                     print("Failed to establish a connection to the microcontroller")
                     send_cmd(CMD_SET_POWER, bytearray([0]))


### PR DESCRIPTION
I am currently working on Solum 7.5" displays (EL075H3BRA) which use an nRF chip that comes locked. Currently, the flasher treats the chip as if it was not connected. This pull requests adds a new return value and a corresponding message, explicitly telling the user that the chip is locked.

- ESP32_Flasher: Return new status "2" when connected, but nRF is locked
- OEPL-Flasher: Print "locked" message when flasher returns status 2
- ESP32_Flasher: Initialize idCode to zero as failed read attempts will not set it
- ESP32_Flasher: Print returned idCode when showDebug is enabled