### PR TITLE
Flasher: Implement "erase" command to unprotect NRF52 based tags

### DIFF
--- a/Tag_Flasher/ESP32_Flasher/include/swd.h
+++ b/Tag_Flasher/ESP32_Flasher/include/swd.h
@@ -56,6 +56,7 @@ class nrfswd : protected swd {
 
     uint8_t nrf_read_bank(uint32_t address, uint32_t buffer[], int size);
     uint8_t nrf_write_bank(uint32_t address, uint32_t buffer[], int size);
+    uint8_t nrf_erase_all();
     uint8_t erase_all_flash();
     uint8_t erase_uicr();
     uint8_t erase_page(uint32_t page);

--- a/Tag_Flasher/ESP32_Flasher/src/swd.cpp
+++ b/Tag_Flasher/ESP32_Flasher/src/swd.cpp
@@ -268,6 +268,20 @@ void nrfswd::write_register(uint32_t address, uint32_t value) {
         Serial0.printf("%i%i%i Write Register: 0x%08x : 0x%08x\r\n", state1, state2, state3, address, value);
 }
 
+uint8_t nrfswd::nrf_erase_all() {
+    nrf_port_selection(1);
+    nrf_write_port(1, AP_NRF_ERASEALL, 1);
+    long timeout = millis();
+    while (nrf_read_port(1, AP_NRF_ERASEALLSTATUS)) {
+        if (millis() - timeout > 1000) return 1;
+    }
+    nrf_write_port(1, AP_NRF_ERASEALL, 0);
+    nrf_port_selection(0);
+    nrf_soft_reset();
+    init();
+    return 0;
+}
+
 uint8_t nrfswd::erase_all_flash() {
     write_register(0x4001e504, 2);
     long timeout = millis();

--- a/Tag_Flasher/ESP32_Flasher/src/usbflasher.cpp
+++ b/Tag_Flasher/ESP32_Flasher/src/usbflasher.cpp
@@ -296,6 +296,7 @@ typedef enum {
 
     CMD_ERASE_FLASH = 26,
     CMD_ERASE_INFOPAGE = 27,
+    CMD_ERASE_ALL = 28,
     CMD_SAVE_MAC_FROM_FW = 40,
     CMD_PASS_THROUGH = 50,
 
@@ -495,6 +496,13 @@ void processFlasherCommand(struct flasherCommand* cmd) {
                 zbsflasherp->zbs->erase_infoblock();
             }
             sendFlasherAnswer(CMD_ERASE_INFOPAGE, NULL, 0);
+            break;
+        case CMD_ERASE_ALL:
+            if (selectedController == CONTROLLER_NRF82511) {
+                if (nrfflasherp == nullptr) return;
+                nrfflasherp->nrf_erase_all();
+            }
+            sendFlasherAnswer(CMD_ERASE_ALL, NULL, 0);
             break;
         case CMD_SELECT_PORT:
             selectedFlasherPort = cmd->data[0];

--- a/Tag_Flasher/OEPL-Flasher.py
+++ b/Tag_Flasher/OEPL-Flasher.py
@@ -15,6 +15,7 @@ CMD_SET_TESTP = 14
 
 CMD_ERASE_FLASH = 26
 CMD_ERASE_INFOPAGE = 27
+CMD_ERASE_ALL = 28
 CMD_SAVE_MAC_FROM_FW = 40
 CMD_PASS_THROUGH = 50
 
@@ -281,7 +282,7 @@ def main():
             description="OpenEPaperLink Flasher for AP/Flasher board")
         parser.add_argument("-p", "--port", help="COM port to use")
         parser.add_argument("-t", "--ip", help="IP Address to use")
-        parser.add_argument("command", nargs="?", choices=["read", "write", "autoflash", "debug"], help="Command to execute")
+        parser.add_argument("command", nargs="?", choices=["read", "write", "erase", "autoflash", "debug"], help="Command to execute")
         parser.add_argument("filename", nargs="?",
                             help="Filename for read/write commands")
         parser.add_argument("-f", "--flash", action="store_true",
@@ -360,7 +361,7 @@ def main():
             send_cmd(CMD_SELECT_EEPROM_PT, bytearray([])) ## selects eeprom serial loader mode
             cmd, answer = wait_for_command()
 
-        elif (args.flash or args.infopage):
+        elif (args.flash or args.infopage or args.command == "erase"):
             if (args.command != "debug"):
                 if args.internalap:
                     send_cmd(CMD_SELECT_PORT, bytearray([0]))
@@ -381,9 +382,12 @@ def main():
                 if (answer[0] == 1):
                     print("Connection established to microcontroller")
                 elif (answer[0] == 2):
-                    print("Established connection to the microcontroller, but it is locked. Exiting.")
-                    send_cmd(CMD_SET_POWER, bytearray([0]))
-                    exit(0)
+                    print("Established connection to the microcontroller, but it is locked.")
+                    if args.command != "erase":
+                        print("Call with 'erase' command to remove protection and erase all data.")
+                        print("WARNING: This will render the tag unusable until a new firmware and matching UICR (infopage) are flashed!")
+                        send_cmd(CMD_SET_POWER, bytearray([0]))
+                        exit(0)
                 else:
                     print("Failed to establish a connection to the microcontroller")
                     send_cmd(CMD_SET_POWER, bytearray([0]))
@@ -393,6 +397,15 @@ def main():
             read_from_serial(args.filename, args)
         elif args.command == "write":
             write_to_serial(args.filename, args)
+        elif args.command == "erase":
+            print(f"\nErasing chip... ")
+            send_cmd(CMD_ERASE_ALL, bytearray([]))
+            cmd, answer = wait_for_command()
+            if (cmd == CMD_ERASE_ALL):
+                print("DONE!\n")
+            else:
+                print("\nFailed to erase the chip?")
+                exit(0)
         elif args.command == "autoflash":
             print("Starting automatic tag flash")
             send_cmd(CMD_AUTOFLASH, bytearray([]))


### PR DESCRIPTION
The regular (disregarding glitching) way to remove APPROTECT from NRF52 devices is to issue an "erase all" command. This PR implements this in the Tag_Flasher and the ESP32_Flasher, so that Tags that came locked from the factory can be overwritten with new firmware.
As the UICR holding tag information is also lost, one will need to piece together a new one before the tag can work with e.g. Newton_M3_Universal-full-flash.bin.