### PR TITLE
Bugfix: Update variable minutesUntilNextUpdate to 32-bit integer because of integer overflow

### DIFF
--- a/ESP32_AP-Flasher/src/contentmanager.cpp
+++ b/ESP32_AP-Flasher/src/contentmanager.cpp
@@ -64,7 +64,7 @@ void contentRunner() {
         }
 
         if (taginfo->expectedNextCheckin > now - 10 && taginfo->expectedNextCheckin < now + 30 && taginfo->pendingIdle == 0 && taginfo->pendingCount == 0) {
-            int16_t minutesUntilNextUpdate = (taginfo->nextupdate - now) / 60;
+            int32_t minutesUntilNextUpdate = (taginfo->nextupdate - now) / 60;
             if (minutesUntilNextUpdate > config.maxsleep) {
                 minutesUntilNextUpdate = config.maxsleep;
             }


### PR DESCRIPTION
At time of writing this, when a tag is idle, it will check in once every minute regardless of what you have set your "Maximum sleep" to. This happens because the result of calculating minutesUntilNextUpdate will be a negative number and prepareIdleReq will never be executed. On (Wed Jul 03 2024 00:33:00 GMT+0000) tags will idle as it should again when the calculated value will be a positive number and will work as it is supposed to for approximately ~22,75 days when it will become a negative number again.

Changing the variable to 32-bit instead of 16-bit will resolve this "interval bug".