### PR TITLE
Preprocess *.json files to support conditional "compile" and comments.

### DIFF
--- a/ESP32_AP-Flasher/.gitignore
+++ b/ESP32_AP-Flasher/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+wwwroot/content_cards.json

--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -30,8 +30,24 @@ build_flags =
 	-D DISABLE_ALL_LIBRARY_WARNINGS
 	-D ILI9341_DRIVER
 	-D SMOOTH_FONT
+extra_scripts = pre:preprocess_json.py
 upload_port = COM26
 monitor_port = COM26
+[std_apps]
+apps=
+	-D CONTENT_CAL
+	-D CONTENT_BUIENRADAR
+	-D CONTENT_TAGCFG
+
+[all_apps]
+apps=
+	${std_apps.apps}
+	-D CONTENT_QR
+	-D CONTENT_RSS
+	-D CONTENT_BIGCAL
+	-D CONTENT_NFCLUT
+	-D CONTENT_DAYAHEAD
+	-D CONTENT_TIMESTAMP
 ; ----------------------------------------------------------------------------------------
 ; !!! this configuration expects the Mini_AP
 ; ----------------------------------------------------------------------------------------
@@ -64,6 +80,7 @@ build_flags =
   	-D FLASHER_AP_TEST=12
   	-D FLASHER_LED=15
   	-D FLASHER_RGB_LED=33
+	${std_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>-<ips_display.cpp>-<webflasher.cpp>
 board_build.psram_type=qspi_opi
@@ -100,6 +117,7 @@ build_flags =
   	-D FLASHER_AP_TEST=36
   	-D FLASHER_LED=15
   	-D FLASHER_RGB_LED=-1
+	${std_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>-<ips_display.cpp>-<webflasher.cpp>
 board_build.psram_type=qspi_opi
@@ -160,6 +178,7 @@ build_flags =
 	-D FLASHER_ALT_TEST=13
 	-D FLASHER_LED=21
 	-D FLASHER_RGB_LED=48
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<espflasher.cpp>
 board_build.flash_mode=qio
@@ -192,6 +211,7 @@ build_flags =
 	-D FLASHER_AP_TXD=17
 	-D FLASHER_AP_RXD=16
 	-D FLASHER_LED=22
+	${std_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>-<ips_display.cpp>-<webflasher.cpp>
 ; ----------------------------------------------------------------------------------------
@@ -252,6 +272,7 @@ build_flags =
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
 	-D C6_OTA_FLASHING
 	-D HAS_SUBGHZ
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -301,6 +322,7 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=50
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
 	-D C6_OTA_FLASHING
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -349,6 +371,7 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=50
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
 	-D C6_OTA_FLASHING
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -418,7 +441,8 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=200
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=200
 	-D C6_OTA_FLASHING
-        -D HAS_SUBGHZ
+	-D HAS_SUBGHZ
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -487,7 +511,8 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=200
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=200
 	-D C6_OTA_FLASHING
-        -D HAS_SUBGHZ
+	-D HAS_SUBGHZ
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -535,6 +560,7 @@ build_flags =
 	-D HAS_RGB_LED
 	-D FLASHER_RGB_LED=48
 	-D BLE_ONLY
+	${all_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>-<espflasher.cpp>
 board_build.flash_mode=qio
@@ -581,6 +607,7 @@ build_flags =
 	-D SD_CARD_MISO=36
 	-D SD_CARD_MOSI=14
 	-D SD_CARD_SS=12
+	${all_apps.apps}
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>-<webflasher.cpp>
 board_build.flash_mode=qio
@@ -671,6 +698,7 @@ build_flags =
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=200
 	-D C6_OTA_FLASHING
         -D HAS_SUBGHZ
+	${all_apps.apps}
 build_src_filter = 
 	+<*>
 board_build.flash_mode=qio
@@ -719,6 +747,7 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=50
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
 	-D C6_OTA_FLASHING
+	${std_apps.apps}
 build_src_filter = 
 	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
 board_build.psram_type=qspi_opi
@@ -750,6 +779,7 @@ board_upload.flash_size = 4MB
 ;	-D FLASHER_AP_TXD=19
 ;	-D FLASHER_AP_RXD=23
 ;	-D FLASHER_LED=2
+;	${std_apps.apps}
 ;build_src_filter = 
 ;	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ;board_build.psram_type=qspi_opi
@@ -786,6 +816,7 @@ board_upload.flash_size = 4MB
 ;  	-D FLASHER_AP_TEST=-1
 ;  	-D FLASHER_LED=2
 ;  	-D FLASHER_RGB_LED=-1
+;	${std_apps.apps}
 ;build_src_filter = 
 ;	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ;board_build.psram_type=qspi_opi
@@ -825,6 +856,7 @@ board_upload.flash_size = 4MB
 ;	-D FLASHER_AP_RXD=18
 ;	-D FLASHER_LED=21
 ;	-D FLASHER_RGB_LED=38
+;	${all_apps.apps}
 ;build_src_filter = 
 ;	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ;board_build.flash_mode=opi
@@ -857,6 +889,7 @@ board_upload.flash_size = 4MB
 ;	-D FLASHER_AP_TXD=16
 ;	-D FLASHER_AP_RXD=17
 ;	-D FLASHER_LED=22
+;	${std_apps.apps}
 ;build_src_filter = 
 ;	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ; ----------------------------------------------------------------------------------------
@@ -894,6 +927,7 @@ board_upload.flash_size = 4MB
 ;	-D DISABLE_ALL_LIBRARY_WARNINGS
 ;	-D ILI9341_DRIVER
 ;	-D SMOOTH_FONT
+;	${std_apps.apps}
 ;build_src_filter = 
 ;	+<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ; ----------------------------------------------------------------------------------------
@@ -930,6 +964,7 @@ board_upload.flash_size = 4MB
 ;	-D SERIAL_FLASHER_INTERFACE_UART=1
 ;	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=50
 ;	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
+;	${std_apps.apps}
 ;build_src_filter = 
 ;   +<*>-<usbflasher.cpp>-<swd.cpp>-<espflasher.cpp>
 ;board_build.psram_type=qspi_opi

--- a/ESP32_AP-Flasher/preprocess_json.py
+++ b/ESP32_AP-Flasher/preprocess_json.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import glob
+
+# create runtime wwwroot/*.json from src/*.json
+source_folder = "src"  # Replace with the path of the source folder
+destination_folder = "wwwroot"  # Replace with the path of the destination folder
+
+# Create the destination folder if it doesn't exist
+if not os.path.exists(destination_folder):
+    os.makedirs(destination_folder)
+
+# Get a list of all files in the source folder
+files = glob.glob(f'{source_folder}/*.json')
+
+for source_file_path in files:
+    file = os.path.basename(source_file_path)
+    destination_file_path = os.path.join(destination_folder, file)
+    
+    print(f"preprocessing: {file}")
+    cmd_line = [ 'cpp', '-P',f'{source_file_path}','-o' f'{destination_file_path}' ]
+    if 'Import' in globals() and callable(Import):
+        Import("env")
+        for define in env.get('BUILD_FLAGS', []):
+            if define.startswith('-D CONTENT'):
+                cmd_line.append(define)
+    print(f'Running {cmd_line}')
+
+    subprocess.run(cmd_line)
+

--- a/ESP32_AP-Flasher/src/content_cards.json
+++ b/ESP32_AP-Flasher/src/content_cards.json
@@ -44,14 +44,12 @@
     "desc": "Image from Home Assistant",
     "param": [ ]
   },
-#ifdef CONTENT_BIGCAL
   {
     "id": 1,
     "name": "Current date",
     "desc": "Shows the current date",
     "param": [ ]
   },
-#endif
   {
     "id": 2,
     "name": "Count days",
@@ -210,7 +208,7 @@
     ]
   },
 #endif
-#ifdef CONTENT_QR
+#ifdef CONTENT_RSS
   {
     "id": 9,
     "name": "RSS feed",

--- a/ESP32_AP-Flasher/src/content_cards.json
+++ b/ESP32_AP-Flasher/src/content_cards.json
@@ -1,3 +1,6 @@
+// This file is processed by the C preprocessor to create the run time version.
+// This allows us to embed comments and #ifdefs which are not allowed in
+// Json files.
 [
   {
     "id": 0,
@@ -41,12 +44,14 @@
     "desc": "Image from Home Assistant",
     "param": [ ]
   },
+#ifdef CONTENT_BIGCAL
   {
     "id": 1,
     "name": "Current date",
     "desc": "Shows the current date",
     "param": [ ]
   },
+#endif
   {
     "id": 2,
     "name": "Count days",
@@ -178,6 +183,7 @@
       }
     ]
   },
+#ifdef CONTENT_BUIENRADAR
   {
     "id": 16,
     "name": "Buienradar",
@@ -203,6 +209,8 @@
       }
     ]
   },
+#endif
+#ifdef CONTENT_QR
   {
     "id": 9,
     "name": "RSS feed",
@@ -229,6 +237,7 @@
       }
     ]
   },
+#endif
   {
     "id": 7,
     "name": "Image URL",
@@ -248,6 +257,7 @@
       }
     ]
   },
+#ifdef CONTENT_QR
   {
     "id": 10,
     "name": "QR code",
@@ -268,6 +278,8 @@
       }
     ]
   },
+#endif
+#ifdef CONTENT_CAL
   {
     "id": 11,
     "name": "Google calendar",
@@ -293,6 +305,8 @@
       }
     ]
   },
+#endif
+#ifdef CONTENT_TIMESTAMP
   {
     "id": 26,
     "name": "Time Stamp",
@@ -347,6 +361,8 @@
       }
     ]
   },
+#endif
+#ifdef CONTENT_DAYAHEAD
   {
     "id": 27,
     "name": "Dayahead prices",
@@ -413,6 +429,7 @@
       }      
     ]
   },
+#endif
   {
     "id": 19,
     "name": "Json template",
@@ -557,6 +574,7 @@
       }
     ]
   },
+#ifdef CONTENT_NFCLUT
   {
     "id": 14,
     "name": "Set NFC URL",
@@ -572,6 +590,7 @@
       }
     ]
   },
+#endif
   {
     "id": 15,
     "name": "Send custom LUT",
@@ -600,6 +619,7 @@
       }
     ]
   },
+#ifdef CONTENT_TAGCFG
   {
     "id": 18,
     "name": "Set Tag Config",
@@ -710,6 +730,7 @@
       }
     ]
   },
+#endif
   {
     "id": 5,
     "name": "Firmware update",
@@ -722,5 +743,39 @@
         "type": "binfile"
       }
     ]
+  },
+  {
+    "id": 250,
+    "name": "NOAA Tide Prediction",
+    "desc": "Tide Prediction for today (US only).",
+    "param": [ 
+      {
+        "key": "StationID",
+        "name": "Station ID",
+        "desc": "Station ID or location to search. See https://tidesandcurrents.noaa.gov/tide_predictions.html",
+        "type": "noaaselect"
+      },
+      {
+        "key": "title",
+        "name": "Title",
+        "desc": "Displayed title",
+        "type": "text"
+      },
+      {
+        "key": "PlotHeightValue",
+        "name": "Display height",
+        "desc": "Add water level height to graph",
+        "type": "select",
+        "options": {
+          "0": "no",
+          "1": "yes"
+        }
+      }
+    ]
+  },
+  {
+    "id": 251,
+    "name": "Adafruit Quote",
+    "desc": "Quotes from Adafruit quote API"
   }
 ]

--- a/ESP32_AP-Flasher/src/content_cards.json
+++ b/ESP32_AP-Flasher/src/content_cards.json
@@ -743,39 +743,5 @@
         "type": "binfile"
       }
     ]
-  },
-  {
-    "id": 250,
-    "name": "NOAA Tide Prediction",
-    "desc": "Tide Prediction for today (US only).",
-    "param": [ 
-      {
-        "key": "StationID",
-        "name": "Station ID",
-        "desc": "Station ID or location to search. See https://tidesandcurrents.noaa.gov/tide_predictions.html",
-        "type": "noaaselect"
-      },
-      {
-        "key": "title",
-        "name": "Title",
-        "desc": "Displayed title",
-        "type": "text"
-      },
-      {
-        "key": "PlotHeightValue",
-        "name": "Display height",
-        "desc": "Add water level height to graph",
-        "type": "select",
-        "options": {
-          "0": "no",
-          "1": "yes"
-        }
-      }
-    ]
-  },
-  {
-    "id": 251,
-    "name": "Adafruit Quote",
-    "desc": "Quotes from Adafruit quote API"
   }
 ]

--- a/ESP32_AP-Flasher/src/contentmanager.cpp
+++ b/ESP32_AP-Flasher/src/contentmanager.cpp
@@ -1,18 +1,5 @@
 #include "contentmanager.h"
 
-// possibility to turn off, to save space if needed
-#ifndef SAVE_SPACE
-#define CONTENT_QR
-#define CONTENT_RSS
-#define CONTENT_BIGCAL
-#define CONTENT_NFCLUT
-#define CONTENT_DAYAHEAD
-#define CONTENT_TIMESTAMP
-#endif
-#define CONTENT_CAL
-#define CONTENT_BUIENRADAR
-#define CONTENT_TAGCFG
-
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <HTTPClient.h>


### PR DESCRIPTION
I'm using these changes locally and I would like the team's feedback if they should be merged into the main repo or not.

Goals:
1. Add support for comments and #ifdefs in select .json files.
2. Make it easier to include/exclude content generation via platform.ini defines.

Background:
I've developed some content such as tide level charts which are of limited interest.  I'd like to make that content available as a compile time option, but I don't want to "spam" the content_cards.json file.

One thing I've found frustrating about .json files for years is the lack of support for comments.  I find adding comments to entries like 

```"gridparam": [ 5, 17, 20, "calibrib16.vlw", "tahoma9.vlw", 14 ]```

helpful to avoid needing to find the corresponding code to figure out what the the numbers mean.

Summary of changes:
1. Move select .json files from current locations to new location (currently just content_cards.json).
2. Move #define CONTENT* defines from contentmanager.cpp to platform.ini
3. Add a platformIO extra_script to use the C preprocessor to create the runtime .json file from the source .json file based on the CONTENT* defines from the platform.ini file.

