### PR TITLE
add tag type SOLUM_M3_BWR_22_LITE

### DIFF
--- a/oepl-definitions.h
+++ b/oepl-definitions.h
@@ -56,6 +56,7 @@
 #define SOLUM_M3_BWR_58 0x41
 #define SOLUM_M3_BW_58 0x42
 #define SOLUM_M3_PEGHOOK_BWR_13 0x43
+#define SOLUM_M3_BWR_22_LITE 0x47
 
 // Types using modchip
 #define MODCHIP_HD150_BWR_58 0x50
@@ -85,6 +86,7 @@
 // Solum types - customer data byte 16 in M3 (nRF) UICR
 #define STYPE_SIZE_016 0x40
 #define STYPE_SIZE_022 0x41
+#define STYPE_SIZE_022_LITE 0x51
 #define STYPE_SIZE_026 0x43
 #define STYPE_SIZE_029 0x42
 #define STYPE_SIZE_029_BW 0x4E

--- a/resources/tagtypes/47.json
+++ b/resources/tagtypes/47.json
@@ -1,0 +1,69 @@
+{
+	"name": "M3 2.2\"",
+	"width": 250,
+	"height": 128,
+	"rotatebuffer": 3,
+	"bpp": 2,
+	"colors": 3,
+	"colortable": {
+		"white": [ 255, 255, 255 ],
+		"black": [ 0, 0, 0 ],
+		"red": [ 255, 0, 0 ],
+		"gray": [ 150, 150, 150 ]
+	},
+	"shortlut": 0,
+	"zlib_compression": "27",
+	"options": [ "button", "led" ],
+	"contentids": [ 22, 23, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 16, 17, 18, 19, 20, 26 ],
+	"template": {
+		"1": {
+			"weekday": [ 128, 3, "Signika-SB.ttf", 50 ],
+			"date": [ 128, 62, "Signika-SB.ttf", 40 ]
+		},
+		"2": {
+			"fonts": [ "Signika-SB.ttf", 150, 150, 150, 115, 90, 70 ],
+			"xy": [ 128, 53 ]
+		},
+		"16": {
+			"location": [ 7, 15, "t0_14b_tf" ],
+			"title": [ 210, 11, "glasstown_nbp_tf" ],
+			"cols": [ 4, 121, 10, "glasstown_nbp_tf" ],
+			"bars": [ 10, 110, 8 ]
+		},
+		"4": {
+			"location": [ 5, 3, "fonts/bahnschrift30" ],
+			"wind": [ 245, 3, "fonts/bahnschrift30" ],
+			"temp": [ 10, 60, "fonts/bahnschrift70" ],
+			"icon": [ 240, 20, 70, 2 ],
+			"dir": [ 210, -12, 40 ],
+			"umbrella": [ 175, -50, 25 ]
+		},
+		"8": {
+			"location": [ 5, 12, "t0_14b_tf" ],
+			"column": [ 5, 51 ],
+			"day": [ 28, 18, "fonts/twcondensed20", 41, 108 ],
+			"icon": [ 28, 55, 30 ],
+			"wind": [ 18, 26 ],
+			"line": [ 20, 128 ]
+		},
+		"9": {
+			"title": [ 5, 4, "bahnschrift20.vlw", 25 ],
+			"items": 8,
+			"line": [ 4, 25, "REFSAN12.vlw" ],
+			"desc": [ 0, 5, "", 1 ]
+		},
+		"10": {
+			"title": [ 149, 5, "fonts/bahnschrift20" ],
+			"pos": [ 149, 30 ]
+		},
+		"11": {
+			"mode": 0,
+			"days": 1,
+			"title": [ 10, 2, "fonts/bahnschrift20" ],
+			"date": [ 245, 2 ],
+			"items": 7,
+			"red": [ 0, 21, 256, 14 ],
+			"line": [ 10, 32, 15, "t0_14b_tf", 50 ]
+		}
+	}
+}

--- a/resources/tagtypes/47.json
+++ b/resources/tagtypes/47.json
@@ -1,5 +1,5 @@
 {
-	"name": "M3 2.2\"",
+	"name": "M3 2.2\" LITE",
 	"width": 250,
 	"height": 128,
 	"rotatebuffer": 3,

--- a/tag_types.h
+++ b/tag_types.h
@@ -19,6 +19,7 @@
 #define SOLUM_M3_BWR_16 0x30
 #define SOLUM_M3_BWY_16 0x38
 #define SOLUM_M3_BWR_22 0x31
+#define SOLUM_M3_BWR_22_LITE 0x47
 #define SOLUM_M3_BWY_22 0x39
 #define SOLUM_M3_BWR_26 0x32
 #define SOLUM_M3_BWY_26 0x3A


### PR DESCRIPTION
Let me know if 0x47 is the correct hexadecimal to use. 
I will make PR for [Tag_FW_EFR32xG22](https://github.com/OpenEPaperLink/Tag_FW_EFR32xG22) and [Tag_FW_nRF52811 ](https://github.com/OpenEPaperLink/Tag_FW_nRF52811) once this is merged. 