### PR TITLE
C6 improvements / fixes (ver 0x001f).

### DIFF
--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.c
@@ -42,7 +42,7 @@
 #define ENABLE_LOGGING  0
 
 #if ENABLE_LOGGING
-#define LOG(format, ... ) printf("%s: " format,__FUNCTION__,## __VA_ARGS__)
+#define LOG(format, ... ) printf("%s: " format "\r",__FUNCTION__,## __VA_ARGS__)
 #define LOG_RAW(format, ... ) printf(format,## __VA_ARGS__)
 #else
 #define LOG(format, ... )
@@ -637,7 +637,6 @@ int CC1101_Rx(uint8_t *RxBuf,size_t RxBufLen,uint8_t *pRssi,uint8_t *pLqi)
 
       if(rxBytes < 2) {
       // should have at least 2 bytes, packet len and one byte of data
-         LOGE("Internal error, rxBytes = %d\n",rxBytes);
          Ret = -2;
          break;
       }

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.h
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.h
@@ -31,11 +31,11 @@
 
 // Log to all
 #define LOGA(format, ... ) \
-   uart_printf(format,## __VA_ARGS__)
+   uart_printf(format "\r",## __VA_ARGS__)
 
 // Error log to all
 #define LOGE(format, ... ) \
-   uart_printf("%s#%d: " format,__FUNCTION__,__LINE__,## __VA_ARGS__)
+   uart_printf("%s#%d: " format "\r",__FUNCTION__,__LINE__,## __VA_ARGS__)
 
 /**
  * CC1101 configuration registers

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.h
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.h
@@ -29,6 +29,14 @@
 #ifndef __CC1101_RADIO_H_
 #define __CC1101_RADIO_H_
 
+// Log to all
+#define LOGA(format, ... ) \
+   uart_printf(format,## __VA_ARGS__)
+
+// Error log to all
+#define LOGE(format, ... ) \
+   uart_printf("%s#%d: " format,__FUNCTION__,__LINE__,## __VA_ARGS__)
+
 /**
  * CC1101 configuration registers
  */
@@ -113,6 +121,7 @@ void CC1101_DumpRegs(void);
 void CC1101_reset(void);
 void CC1101_logState(void);
 void CC1101_setRxState(void);
+int CC1101_WaitMISO(const char *Func,int Line,int level);
 
 #endif   // __CC1101_RADIO_H_
 

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
@@ -474,7 +474,7 @@ void processBlockRequest(const uint8_t *buffer, uint8_t forceBlockDownload) {
             lastBlockRequest = getMillis();
         } else {
             // we're talking to another mac, let this mac know we can't accomodate another request right now
-            pr("BUSY!\n");
+            pr("BUSY!\n\r");
             sendCancelXfer(rxHeader->src);
             return;
         }
@@ -496,9 +496,9 @@ void processBlockRequest(const uint8_t *buffer, uint8_t forceBlockDownload) {
         if (forceBlockDownload) {
             if ((getMillis() - nextBlockAttempt) > 380) {
                 requestDataDownload = true;
-                pr("FORCED\n");
+                pr("FORCED\n\r");
             } else {
-                pr("IGNORED\n");
+                pr("IGNORED\n\r");
             }
         }
     }
@@ -647,7 +647,7 @@ void sendPart(uint8_t partNo) {
 }
 void sendBlockData() {
     if (getBlockDataLength() == 0) {
-        pr("Invalid block request received, 0 parts..\n");
+        pr("Invalid block request received, 0 parts..\n\r");
         requestedData.requestedParts[0] |= 0x01;
     }
 
@@ -660,7 +660,7 @@ void sendBlockData() {
             pr(".");
         }
     }
-    pr("\n");
+    pr("\n\r");
 
     uint8_t partNo = 0;
     while (partNo < BLOCK_MAX_PARTS) {

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
@@ -44,7 +44,7 @@ const uint8_t channelList[6] = {11, 15, 20, 25, 26, 27};
 struct pendingData pendingDataArr[MAX_PENDING_MACS];
 
 // VERSION GOES HERE!
-uint16_t version = 0x001e;
+uint16_t version = 0x001f;
 
 #define RAW_PKT_PADDING 2
 

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/radio.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/radio.c
@@ -54,7 +54,11 @@ void esp_ieee802154_transmit_failed(const uint8_t *frame, esp_ieee802154_tx_erro
 void esp_ieee802154_transmit_done(const uint8_t *frame, const uint8_t *ack, esp_ieee802154_frame_info_t *ack_frame_info) {
     isInTransmit = 0;
     ESP_EARLY_LOGI(TAG, "TX %d", frame[0]);
-   esp_ieee802154_receive_handle_done(ack);
+    if(ack != NULL) {
+       if(esp_ieee802154_receive_handle_done(ack)) {
+          ESP_EARLY_LOGI(TAG, "esp_ieee802154_receive_handle_done() failed");
+       }
+    }
 }
 static bool zigbee_is_enabled = false;
 void radio_init(uint8_t ch) {


### PR DESCRIPTION
1. Add 2 millisecond timeout for all SubGhz MISO wait loops to prevent watchdog timeouts when/if bad things happen (none observed during testing)
2. Make CC1101 detection more robust and less intrusive by testing MISO and CSn before trying to read chip version number.
3. Remove RxFifo overflow "error" reporting since it's confusing to users.
4. Only call esp_ieee802154_receive_handle_done() when ack != NULL. This is the "fix" for 802.15.4 problems with C6 version 0x001e.