### PR TITLE
add support for waveshare ESP32-S3-ETH board

### DIFF
--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/compile.ps1
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/compile.ps1
@@ -1,4 +1,4 @@
-&(Join-Path $env:USERPROFILE '\esp\esp-idf\export.ps1')
+&(Join-Path $env:USERPROFILE '\esp\v5.3.2\esp-idf\export.ps1')
 
 idf.py fullclean
 

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_H2_AP/compile.ps1
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_H2_AP/compile.ps1
@@ -6,7 +6,7 @@
 #| Uart                               | ESP32H2_TX_IO24       | ESP32S3_RX_IO48
 #| Uart                               | ESP32H2_RX_IO23       | ESP32S3_TX_IO47
 
-&(Join-Path $env:USERPROFILE '\esp\esp-idf\export.ps1')
+&(Join-Path $env:USERPROFILE '\esp\v5.3.2\esp-idf\export.ps1')
 
 idf.py fullclean
 

--- a/ESP32_AP-Flasher/compilewaveshareeth.ps1
+++ b/ESP32_AP-Flasher/compilewaveshareeth.ps1
@@ -1,0 +1,53 @@
+#C6                                   WAVESHARE ETH
+#GND
+#3V
+#RST EN       FLASHER_AP_RESET        IO21
+#2            FLASHER_AP_TXD          IO16
+#3            FLASHER_AP_RXD          IO0
+#9   GPIO9    FLASHER_DEBUG_PROG      IO17
+
+#TX  GPIO16   FLASHER_DEBUG_TXD       IO18
+#RX  GPIO17   FLASHER_DEBUG_RXD       IO15
+
+#	-D FLASHER_AP_RESET=21
+#	-D FLASHER_AP_TXD=16
+#	-D FLASHER_AP_RXD=0
+#	-D FLASHER_DEBUG_PROG=17
+#	-D FLASHER_DEBUG_TXD=18
+#	-D FLASHER_DEBUG_RXD=15
+
+# cd ESP32_AP-Flasher
+
+# export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+
+python gzip_wwwfiles.py
+
+&(Join-Path $env:USERPROFILE '\.platformio\penv\Scripts\pio') run --environment ESP32_S3_16_8_WAVESHARE_ETH_AP
+
+&(Join-Path $env:USERPROFILE '\.platformio\penv\Scripts\pio') run --target buildfs --environment ESP32_S3_16_8_WAVESHARE_ETH_AP
+
+# mkdir ESP32_S3_16_8_WAVESHARE_ETH_AP
+
+copy "$env:USERPROFILE\.platformio\packages\framework-arduinoespressif32\tools\partitions\boot_app0.bin" ESP32_S3_16_8_WAVESHARE_ETH_AP\boot_app0.bin
+
+copy .pio\build\ESP32_S3_16_8_WAVESHARE_ETH_AP\firmware.bin ESP32_S3_16_8_WAVESHARE_ETH_AP\firmware.bin
+
+copy .pio\build\ESP32_S3_16_8_WAVESHARE_ETH_AP\bootloader.bin ESP32_S3_16_8_WAVESHARE_ETH_AP\bootloader.bin
+
+copy .pio\build\ESP32_S3_16_8_WAVESHARE_ETH_AP\partitions.bin ESP32_S3_16_8_WAVESHARE_ETH_AP\partitions.bin
+
+copy .pio\build\ESP32_S3_16_8_WAVESHARE_ETH_AP\littlefs.bin ESP32_S3_16_8_WAVESHARE_ETH_AP\littlefs.bin
+
+copy ESP32_S3_16_8_WAVESHARE_ETH_AP\firmware.bin espbinaries\ESP32_S3_16_8_WAVESHARE_ETH_AP.bin
+
+copy ESP32_S3_16_8_WAVESHARE_ETH_AP\merged-firmware.bin espbinaries\ESP32_S3_16_8_WAVESHARE_ETH_AP_full.bin
+
+cd ESP32_S3_16_8_WAVESHARE_ETH_AP
+
+#python -m esptool                         --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin 0x00910000 littlefs.bin
+
+#python -m esptool -p COM3 -b 460800 --before default_reset --after hard_reset --chip esp32s3  write_flash --flash_mode dio --flash_size detect 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin 0x00910000 littlefs.bin
+
+cd ..
+
+

--- a/ESP32_AP-Flasher/include/SPIFFSEditor.h
+++ b/ESP32_AP-Flasher/include/SPIFFSEditor.h
@@ -1,6 +1,10 @@
 #ifndef SPIFFSEditor_H_
 #define SPIFFSEditor_H_
-#include <ESPAsyncWebServer.h>
+#ifdef W5500_ETH
+  #include <AsyncWebServer_ESP32_SC_W5500.h>
+#else
+  #include <ESPAsyncWebServer.h>
+#endif
 
 class SPIFFSEditor: public AsyncWebHandler {
   private:

--- a/ESP32_AP-Flasher/include/web.h
+++ b/ESP32_AP-Flasher/include/web.h
@@ -1,7 +1,11 @@
 
 #include <Arduino.h>
 #include <AsyncTCP.h>
-#include <ESPAsyncWebServer.h>
+#ifdef W5500_ETH
+  #include <AsyncWebServer_ESP32_SC_W5500.h>
+#else
+  #include <ESPAsyncWebServer.h>
+#endif
 
 void init_web();
 void doImageUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);

--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -261,6 +261,71 @@ board_upload.maximum_size = 16777216
 board_upload.maximum_ram_size = 327680
 board_upload.flash_size = 16MB
 ; ----------------------------------------------------------------------------------------
+; !!! this configuration expects an ESP32-S3 16MB Flash 8MB RAM and a WAVESHARE ESP32-S3-ETH board
+; ----------------------------------------------------------------------------------------
+[env:ESP32_S3_16_8_WAVESHARE_ETH_AP]
+board = esp32-s3-devkitc-1
+board_build.partitions = large_spiffs_16MB.csv
+build_unflags =
+	-std=gnu++11
+    -D CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
+lib_deps = 
+	khoih-prog/AsyncWebServer_ESP32_SC_W5500@>=1.8.1
+	bblanchon/ArduinoJson@^6.19.4
+	bodmer/TFT_eSPI
+	https://github.com/Bodmer/TJpg_Decoder.git
+	https://github.com/nlimper/shoddyxml2
+	https://github.com/nlimper/QRCodeGenerator
+	fastled/FastLED@3.7.8
+	https://github.com/MajenkoLibraries/SoftSPI
+build_flags = 
+	-std=gnu++17
+	${env.build_flags}
+	-D CORE_DEBUG_LEVEL=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+	-D CONFIG_ESP32S3_SPIRAM_SUPPORT=1
+	-D CONFIG_SPIRAM_USE_MALLOC=1
+	-D POWER_NO_SOFT_POWER
+	-D BOARD_HAS_PSRAM
+	-D CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
+	-D HAS_BLE_WRITER
+	-D FLASHER_AP_SS=-1
+	-D FLASHER_AP_CLK=-1
+	-D FLASHER_AP_MOSI=-1
+	-D FLASHER_AP_MISO=-1
+	-D FLASHER_AP_RESET=21
+	-D FLASHER_AP_POWER={-1}
+	-D FLASHER_AP_TEST=-1
+	-D FLASHER_AP_TXD=16
+	-D FLASHER_AP_RXD=0
+	-D FLASHER_DEBUG_TXD=18
+	-D FLASHER_DEBUG_RXD=15
+	-D FLASHER_DEBUG_PROG=17
+	-D FLASHER_LED=-1
+	-D USE_HSPI_PORT
+	-D LOAD_FONT2
+	-D MD5_ENABLED=1
+	-D SERIAL_FLASHER_INTERFACE_UART=1
+	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=50
+	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=100
+	-D C6_OTA_FLASHING
+	-D HAS_SUBGHZ
+	-D W5500_ETH	
+	-D ETH_MISO_GPIO=12
+	-D ETH_MOSI_GPIO=11
+        -D ETH_SCK_GPIO=13
+        -D ETH_CS_GPIO=14
+        -D ETH_INT_GPIO=10
+        -D ETH_RST_PIN=9
+build_src_filter = 
+	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
+board_build.flash_mode=qio
+board_build.arduino.memory_type = qio_opi ;Enable external PSRAM
+board_build.psram_type=qspi_opi
+board_upload.maximum_size = 16777216
+board_upload.maximum_ram_size = 327680
+board_upload.flash_size = 16MB
+; ----------------------------------------------------------------------------------------
 ; !!! this configuration expects an ESP32-S3 16MB Flash 8MB RAM
 ; ----------------------------------------------------------------------------------------
 [env:ESP32_S3_16_8_LILYGO_AP]

--- a/ESP32_AP-Flasher/src/main.cpp
+++ b/ESP32_AP-Flasher/src/main.cpp
@@ -11,7 +11,9 @@
 #include "system.h"
 #include "tag_db.h"
 #include "tagdata.h"
-#include "wifimanager.h"
+#ifndef W5500_ETH
+  #include "wifimanager.h"
+#endif
 
 #ifdef HAS_EXT_FLASHER
 #include "webflasher.h"
@@ -171,7 +173,9 @@ void setup() {
 
 void loop() {
     ws.cleanupClients();
-    wm.poll();
+    #ifndef W5500_ETH
+        wm.poll();
+    #endif
 
     if (intervalSysinfo.doRun()) {
         wsSendSysteminfo();

--- a/ESP32_AP-Flasher/src/serialap.cpp
+++ b/ESP32_AP-Flasher/src/serialap.cpp
@@ -733,7 +733,11 @@ void checkWaitPowerCycle() {
 #endif
 }
 void segmentedShowIp() {
-    IPAddress IP = WiFi.localIP();
+    #ifndef W5500_ETH
+        IPAddress IP = WiFi.localIP();
+    #else
+        IPAddress IP = ETH.localIP();
+    #endif
     char temp[12];
     vTaskDelay(2000 / portTICK_PERIOD_MS);
     sendAPSegmentedData(apInfo.mac, (String) "IP    Addr", 0x0200, true, true);

--- a/ESP32_AP-Flasher/src/system.cpp
+++ b/ESP32_AP-Flasher/src/system.cpp
@@ -7,16 +7,20 @@
 
 #include "storage.h"
 #include "tag_db.h"
-#include "wifimanager.h"
+#ifndef W5500_ETH
+  #include "wifimanager.h"
+#endif
 
 void timeSyncCallback(struct timeval* tv) {
     Serial.println("time succesfully synced");
 }
 
 void initTime(void* parameter) {
-    if (WiFi.status() != WL_CONNECTED) {
-        vTaskDelay(500 / portTICK_PERIOD_MS);
-    }
+    #ifndef W5500_ETH
+        if (WiFi.status() != WL_CONNECTED) {
+            vTaskDelay(500 / portTICK_PERIOD_MS);
+        }
+    #endif
     sntp_set_time_sync_notification_cb(timeSyncCallback);
     sntp_set_sync_interval(300 * 1000);
     configTzTime(config.timeZone, "time.cloudflare.com", "pool.ntp.org", "time.nist.gov");

--- a/ESP32_AP-Flasher/src/udp.cpp
+++ b/ESP32_AP-Flasher/src/udp.cpp
@@ -34,7 +34,12 @@ void UDPcomm::init() {
     if (config.discovery == 0) {
         if (udp.listenMulticast(UDPIP, UDPPORT)) {
             udp.onPacket([this](AsyncUDPPacket packet) {
-                if (packet.remoteIP() != WiFi.localIP()) {
+			    #ifndef W5500_ETH
+			        IPAddress IP1 = WiFi.localIP();
+			    #else
+			        IPAddress IP1 = ETH.localIP();
+			    #endif
+                if (packet.remoteIP() != IP1) {
                     this->processPacket(packet);
                 }
             });
@@ -42,7 +47,12 @@ void UDPcomm::init() {
     } else {
         if (udp.listen(UDPPORT)) {
             udp.onPacket([this](AsyncUDPPacket packet) {
-                if (packet.isBroadcast() && packet.remoteIP() != WiFi.localIP()) {
+			    #ifndef W5500_ETH
+			        IPAddress IP2 = WiFi.localIP();
+			    #else
+			        IPAddress IP2 = ETH.localIP();
+			    #endif
+                if (packet.isBroadcast() && packet.remoteIP() != IP2) {
                     this->processPacket(packet);
                 }
             });
@@ -87,8 +97,13 @@ void UDPcomm::processPacket(AsyncUDPPacket packet) {
             break;
         }
         case PKT_APLIST_REQ: {
+		    #ifndef W5500_ETH
+		        IPAddress IP = WiFi.localIP();
+		    #else
+		        IPAddress IP = ETH.localIP();
+		    #endif
             APlist APitem;
-            APitem.src = WiFi.localIP();
+            APitem.src = IP;
             strcpy(APitem.alias, config.alias);
             APitem.channelId = curChannel.channel;
             APitem.tagCount = getTagCount();
@@ -153,8 +168,13 @@ void autoselect(void* pvParameters) {
 }
 
 void UDPcomm::getAPList() {
+    #ifndef W5500_ETH
+        IPAddress IP = WiFi.localIP();
+    #else
+        IPAddress IP = ETH.localIP();
+    #endif
     APlist APitem;
-    APitem.src = WiFi.localIP();
+    APitem.src = IP;
     strcpy(APitem.alias, config.alias);
     APitem.channelId = curChannel.channel;
     APitem.tagCount = getTagCount();


### PR DESCRIPTION
There is a new environment ESP32_S3_16_8_WAVESHARE_ETH_AP 

C6 firmware is the same as for yellow AP

| C6  |  |  WAVESHARE ETH  |
|-------------|----------------------------|----------|
| GND          |                                           |  GND   |
| 3V              |                                           | 3V        |
| RST EN       | FLASHER_AP_RESET          | IO21 |
| 2                 | FLASHER_AP_TXD             | IO16 |
| 3                 | FLASHER_AP_RXD             | IO0 |
| 9   GPIO9    | FLASHER_DEBUG_PROG   | IO17 |
| TX  GPIO16 | FLASHER_DEBUG_TXD      | IO18 |
|RX  GPIO17  | FLASHER_DEBUG_RXD      | IO15 |
