### PR TITLE
Created new AP setup using the Lilygo T-Display-S3 board

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,24 @@ jobs:
           cp ESP32_S3_16_8_LILYGO_AP/firmware.bin espbinaries/ESP32_S3_16_8_LILYGO_AP.bin
           cp ESP32_S3_16_8_LILYGO_AP/merged-firmware.bin espbinaries/ESP32_S3_16_8_LILYGO_AP_full.bin
 
+      - name: Build firmware for ESP32_S3_16_8_LILYGO_T3
+        run: |
+          cd ESP32_AP-Flasher
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          pio run --environment ESP32_S3_16_8_LILYGO_T3
+          pio run --target buildfs --environment ESP32_S3_16_8_LILYGO_T3
+          mkdir /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3/boot_app0.bin
+          cp .pio/build/ESP32_S3_16_8_LILYGO_T3/firmware.bin /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3/firmware.bin
+          cp .pio/build/ESP32_S3_16_8_LILYGO_T3/bootloader.bin /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3/bootloader.bin
+          cp .pio/build/ESP32_S3_16_8_LILYGO_T3/partitions.bin /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3/partitions.bin
+          cp .pio/build/ESP32_S3_16_8_LILYGO_T3/littlefs.bin /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3/littlefs.bin
+          cd /home/runner/work/OpenEPaperLink/OpenEPaperLink/ESP32_S3_16_8_LILYGO_T3
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin 0x00910000 littlefs.bin
+          cd /home/runner/work/OpenEPaperLink/OpenEPaperLink
+          cp ESP32_S3_16_8_LILYGO_T3/firmware.bin espbinaries/ESP32_S3_16_8_LILYGO_T3.bin
+          cp ESP32_S3_16_8_LILYGO_T3/merged-firmware.bin espbinaries/ESP32_S3_16_8_LILYGO_T3_full.bin
+
       - name: Build firmware for OpenEPaperLink_Nano_TLSR
         run: |
           cd ESP32_AP-Flasher

--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -218,6 +218,95 @@ board_upload.maximum_ram_size = 327680
 board_upload.flash_size = 16MB
 ; ----------------------------------------------------------------------------------------
 ; !!! this configuration expects an ESP32-S3 16MB Flash 8MB RAM
+; !!! Dedicated pinout for using the Lilygo T-Display-S3 board.
+; ----------------------------------------------------------------------------------------
+[env:ESP32_S3_16_8_LILYGO_T3]
+board = esp32-s3-devkitc-1
+board_build.partitions = large_spiffs_16MB.csv
+monitor_dtr = 0
+monitor_rts = 0
+build_unflags =
+	-std=gnu++11
+	-D CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
+	-D ILI9341_DRIVER
+lib_deps = 	${env.lib_deps}
+build_flags = 
+	-std=gnu++17
+	${env.build_flags}
+	-D HAS_TFT
+	-D CORE_DEBUG_LEVEL=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D CONFIG_ESP32S3_SPIRAM_SUPPORT=1
+	-D CONFIG_SPIRAM_USE_MALLOC=1
+	-D POWER_NO_SOFT_POWER
+	-D BOARD_HAS_PSRAM
+	-D CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
+	-D HAS_BLE_WRITER
+	-D FLASHER_AP_SS=-1
+	-D FLASHER_AP_CLK=-1
+	-D FLASHER_AP_MOSI=-1
+	-D FLASHER_AP_MISO=-1
+	-D FLASHER_AP_RESET=44 ;47 ;purple RST
+	-D FLASHER_AP_POWER={-1}
+	-D FLASHER_AP_TEST=-1
+	-D FLASHER_AP_TXD=17 ;white 2
+	-D FLASHER_AP_RXD=18 ;orange 3
+	-D FLASHER_DEBUG_TXD=12 ;15  ;yellow TX
+	-D FLASHER_DEBUG_RXD=13 ;7 ;blue RX
+	-D FLASHER_DEBUG_PROG=21 ;green 9
+	-D FLASHER_LED=-1
+	-D HAS_RGB_LED
+	-D FLASHER_RGB_LED=48
+	-D ST7789_DRIVER
+	;-D ST7735_DRIVER
+	;-D ST7735_GREENTAB160x80
+	-D TFT_INVERSION_ON
+	-D TFT_PARALLEL_8_BIT
+	-D TFT_WIDTH=170 ;80
+	-D TFT_HEIGHT=320 ;160
+	;-D TFT_MISO=-1
+	;-D TFT_MOSI=13
+	;-D TFT_SCLK=12
+	-D TFT_WR=8
+	-D TFT_RD=9
+	-D TFT_CS=6 ;10
+	-D TFT_DC=7 ;11
+	-D TFT_RST=5 ;1
+	-D TFT_D0=39
+	-D TFT_D1=40
+	-D TFT_D2=41
+	-D TFT_D3=42
+	-D TFT_D4=45
+	-D TFT_D5=46
+	-D TFT_D6=47
+	-D TFT_D7=48
+	-D TFT_BL=38
+	-D TFT_RGB_ORDER=TFT_BGR
+	-D USE_HSPI_PORT
+	-D LOAD_FONT2
+	-D LOAD_FONT4
+	-D LOAD_GLCD
+	;-D LOAD_FONT6
+	;-D LOAD_FONT7
+	;-D LOAD_FONT8
+	;-D LOAD_GFXFF
+	;-D SMOOTH_FONT
+	-D MD5_ENABLED=1
+	-D SERIAL_FLASHER_INTERFACE_UART=1
+	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=200
+	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=200
+	-D C6_OTA_FLASHING
+	;-D HAS_SUBGHZ ; disabled for now, not sure if needed/applicable
+build_src_filter = 
+	+<*>-<usbflasher.cpp>-<swd.cpp>-<webflasher.cpp>
+board_build.flash_mode=qio
+board_build.arduino.memory_type = qio_opi
+board_build.psram_type=qspi_opi
+board_upload.maximum_size = 16777216
+board_upload.maximum_ram_size = 327680
+board_upload.flash_size = 16MB
+; ----------------------------------------------------------------------------------------
+; !!! this configuration expects an ESP32-S3 16MB Flash 8MB RAM
 ; ----------------------------------------------------------------------------------------
 [env:ESP32_S3_C6_BIG_AP]
 board = esp32-s3-devkitc-1


### PR DESCRIPTION
I would like to propose a new AP setup to the default available setups.
This one uses the Lilygo T-Display-S3 board with a build-in TFT display for easy AP information.