### PR TITLE
Comment out defined ports

### DIFF
--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -30,8 +30,9 @@ build_flags =
 	-D DISABLE_ALL_LIBRARY_WARNINGS
 	-D ILI9341_DRIVER
 	-D SMOOTH_FONT
-upload_port = COM26
-monitor_port = COM26
+# Without defined ports, platformio will autodetect the ports. Best for most usecases.
+#upload_port = COM26
+#monitor_port = COM26
 ; ----------------------------------------------------------------------------------------
 ; !!! this configuration expects the 16MB Flash / 8MB Ram version of the ESP32-S3-DevkitC1
 ; ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Without defined ports, platformio will autodetect the ports. Best for most usecases.