### PR TITLE
css: fallback to 'monospace' for AP log view

### DIFF
--- a/ESP32_AP-Flasher/wwwroot/main.css
+++ b/ESP32_AP-Flasher/wwwroot/main.css
@@ -876,7 +876,7 @@ h4 {
 .console {
 	width: 450px;
 	background-color: black;
-	font-family: 'lucida console', 'ui-monospace';
+	font-family: 'lucida console', 'ui-monospace', 'monospace';
 	color: white;
 	padding: 5px 10px;
 	padding-bottom: 25px;


### PR DESCRIPTION
Log view on firmware update page was not printed using fixed width font on my system.

Now it is.

Closes: #460