### PR TITLE
Ability to update time without requiring Internet Access

### DIFF
--- a/ESP32_AP-Flasher/src/serialap.cpp
+++ b/ESP32_AP-Flasher/src/serialap.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <HardwareSerial.h>
 #include <system.h>
+#include <WiFi.h>
 
 #include "commstructs.h"
 #include "contentmanager.h"


### PR DESCRIPTION
I was having an issue with https://github.com/OpenEPaperLink/OpenEPaperLink/issues/495 so I have now added a way to update the timeserver externally and use OEPL without internet access. 